### PR TITLE
Ajout du ruleset pour la branche main ✅

### DIFF
--- a/.github/workflows/branch_main_rules.yml
+++ b/.github/workflows/branch_main_rules.yml
@@ -1,0 +1,26 @@
+name: Protect main branch
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened]
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log branch info
+        run: |
+          echo "Head branch: ${{ github.event.pull_request.head.ref }}"
+          echo "Base branch: ${{ github.event.pull_request.base.ref }}"
+      - name: Check branch
+        run: |
+          if [[ ${{ github.event.pull_request.head.ref }} == "dev" && ${{ github.event.pull_request.base.ref }} == "main" ]]; then
+            echo "This PR is from the dev branch to the main branch"
+            exit 0
+          else
+            echo "This PR is not from the dev branch to the main branch"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Closes #6 
### **Contexte** 📖  
Cette PR introduit un ensemble de règles de protection pour la branche `main` afin de garantir la stabilité et la qualité du code. Ces protections sont essentielles pour éviter les modifications non validées et pour structurer le processus de contribution.

---

### **Modifications principales** ✨  
1. **Configuration des protections pour la branche `main`** :
   - Blocage des pushs directs sur `main`.  
   - Requiert au moins **1 approbation de review** pour les Pull Requests.  
   - Exige que les workflows CI passent avec succès avant le merge.  
2. Mise à jour du fichier `README.md` pour documenter les nouvelles règles de contribution.  

---

### **Impact attendu** 🌟  
- Amélioration de la stabilité de la branche `main`.  
- Renforcement du processus de revue de code.  
- Réduction des risques d'intégration de code non testé ou non validé.  

---

### **Étapes de validation** ✅  
- [ ] Vérifier que les protections sont bien activées dans les paramètres GitHub.  
- [ ] Confirmer que les nouvelles règles sont respectées lors de la création de Pull Requests.  

---

### **Ressources utiles** 📚  
- [[Documentation sur les protections de branches GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-protected-branches)](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-protected-branches)  

---

Si tout est bon, cette PR peut être mergée pour activer les nouvelles règles sur `main` ! 🚀